### PR TITLE
Implement RP-Initiated Logout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,6 @@
 #
 # This is an example environment variable configuration file.
-# ... See https://github.com/motdotla/dotenv#usage for more information on how to use a .env file.
-#
-
-#
-# Choose a login.gov environment:
+# ... see https://github.com/motdotla/dotenv#usage for more information on how to use a .env file.
 #
 
 DISCOVERY_URL="https://idp.int.login.gov/"
-
-#
-# Optionally override this application's service provider configuration:
-#
-
-CLIENT_ID="urn:gov:gsa:openidconnect:sp:expressjs"
-KEY_FILE_PATH="./keys/login-gov/expressjs_demo_sp.key"
-PORT="9393"

--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ mailcatcher -f
 
 ## Usage
 
-This application runs on http://localhost:9393 by default, however you can configure it to run on a different port by overriding the `PORT` environment variable.
-
-Run this client application on a local webserver:
+Run this client application on a local web server:
 
 ```sh
 DEBUG=identity-oidc-expressjs:* npm start # then view localhost:9393 in a browser

--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ var bodyParser = require('body-parser');
 var passport = require('passport');
 var session = require('express-session');
 
-var loginGovStrategy = require('./login-gov');
+var loginGov = require('./login-gov');
 
 var loginGovRoutes = require('./routes/auth/login-gov');
 var index = require('./routes/index');
@@ -44,8 +44,8 @@ app.use(passport.session());
 passport.serializeUser(function(user, done) { done(null, user); });
 passport.deserializeUser(function(user, done) { done( null, user); }); // this is where you might fetch a user record from the database. see http://www.passportjs.org/docs/configure/#sessions
 
-loginGovStrategy.configure(passport, 1); // configure LOA1 strategy
-loginGovStrategy.configure(passport, 3); // configure LOA3 strategy
+loginGov.configure(passport, 1); // configure LOA1 strategy
+loginGov.configure(passport, 3); // configure LOA3 strategy
 
 loginGovRoutes.configure(app, passport); // use login.gov auth routes
 app.use('/', index);

--- a/bin/www
+++ b/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '9393');
+var port = normalizePort('9393'); // var port = normalizePort(process.env.PORT || '9393') // FYI login.gov as currently configured only recognizes this example client app when run on port 9393
 app.set('port', port);
 
 /**

--- a/login-gov.js
+++ b/login-gov.js
@@ -12,7 +12,7 @@ var key = fs.readFileSync(keyFile, 'ascii');
 var jwk = pem2jwk(key);
 var keys = [jwk];
 
-var discoveryUrl = process.env.DISCOVERY_URL || 'http://localhost:3000';
+loginGov.discoveryUrl = process.env.DISCOVERY_URL || 'http://localhost:3000';
 
 var clientOptions = {
   client_id: process.env.CLIENT_ID || 'urn:gov:gsa:openidconnect:sp:expressjs',
@@ -26,8 +26,8 @@ function strategyParams(loaNumber){
     acr_values: `http://idmanagement.gov/ns/assurance/loa/${loaNumber}`,
     scope: 'openid email address phone profile:birthdate profile:name profile social_security_number',
     redirect_uri: `http://localhost:${(process.env.PORT || '9393')}/auth/login-gov/callback/loa-${loaNumber}`,
-    nonce: randomString(32),
-    state: randomString(32),
+    nonce: loginGov.randomString(32),
+    state: loginGov.randomString(32),
     prompt: 'select_account'
   };
 };
@@ -37,7 +37,7 @@ loginGov.configure = function(passport, loaNumber){
 
   Promise.all([
     jose.JWK.asKeyStore(keys),
-    Issuer.discover(discoveryUrl)
+    Issuer.discover(loginGov.discoveryUrl)
   ]).then(function([keystore, issuer]){
     var client = new issuer.Client(clientOptions, keystore);
 
@@ -59,7 +59,7 @@ loginGov.configure = function(passport, loaNumber){
   });
 };
 
-function randomString(length) {
+loginGov.randomString = function(length) {
   return crypto.randomBytes(length).toString('hex'); // source: https://github.com/18F/fs-permit-platform/blob/c613a73ae320980e226d301d0b34881f9d954758/server/src/util.es6#L232-L237
 };
 

--- a/login-gov.js
+++ b/login-gov.js
@@ -40,20 +40,23 @@ loginGov.configure = function(passport, loaNumber){
     Issuer.discover(loginGov.discoveryUrl)
   ]).then(function([keystore, issuer]){
     loginGov.issuer = issuer; // allow subsequent access to issuer.end_session_endpoint (required during OIDC logout)
+
     var client = new issuer.Client(clientOptions, keystore);
+
     var params = strategyParams(loaNumber);
-    var strategy = new Strategy(
-      {client: client, params: params},
-      function(tokenset, userinfo, done) {
-        console.log("TOKEN SET", Object.keys(tokenset), tokenset)
-        console.log("USER INFO", Object.keys(userinfo), userinfo)
-        userinfo.token = tokenset.id_token // required for OIDC logout
-        userinfo.state = params.state // required for OIDC logout
-        return done(null, userinfo);
-      }
-    );
+
+    var strategy = new Strategy({client: client, params: params}, function(tokenset, userinfo, done) {
+      console.log("TOKEN SET", tokenset); // don't log in production
+      console.log("USER INFO", userinfo); // don't log in production
+      userinfo.token = tokenset.id_token; // required for OIDC logout
+      userinfo.state = params.state; // required for OIDC logout
+      return done(null, userinfo);
+    });
+
     passport.use(`oidc-loa-${loaNumber}`, strategy);
+
     console.log("LOGIN.GOV CONFIGURATION SUCCESS", `(LOA${loaNumber})`);
+
   }).catch(function(err){
     console.log("LOGIN.GOV CONFIGURATION ERROR", err);
   });

--- a/login-gov.js
+++ b/login-gov.js
@@ -7,7 +7,7 @@ var Strategy = require('openid-client').Strategy;
 
 var loginGov = {};
 
-var keyFile = process.env.KEY_FILE_PATH || './keys/login-gov/expressjs_demo_sp.key';
+var keyFile = './keys/login-gov/expressjs_demo_sp.key';
 var key = fs.readFileSync(keyFile, 'ascii');
 var jwk = pem2jwk(key);
 var keys = [jwk];
@@ -15,7 +15,7 @@ var keys = [jwk];
 loginGov.discoveryUrl = process.env.DISCOVERY_URL || 'http://localhost:3000';
 
 var clientOptions = {
-  client_id: process.env.CLIENT_ID || 'urn:gov:gsa:openidconnect:sp:expressjs',
+  client_id: 'urn:gov:gsa:openidconnect:sp:expressjs',
   token_endpoint_auth_method: 'private_key_jwt',
   id_token_signed_response_alg: 'RS256'
 };
@@ -25,7 +25,7 @@ function strategyParams(loaNumber){
     response_type: 'code',
     acr_values: `http://idmanagement.gov/ns/assurance/loa/${loaNumber}`,
     scope: 'openid email address phone profile:birthdate profile:name profile social_security_number',
-    redirect_uri: `http://localhost:${(process.env.PORT || '9393')}/auth/login-gov/callback/loa-${loaNumber}`,
+    redirect_uri: `http://localhost:9393/auth/login-gov/callback/loa-${loaNumber}`,
     nonce: loginGov.randomString(32),
     state: loginGov.randomString(32),
     prompt: 'select_account'

--- a/login-gov.js
+++ b/login-gov.js
@@ -39,17 +39,17 @@ loginGov.configure = function(passport, loaNumber){
     jose.JWK.asKeyStore(keys),
     Issuer.discover(loginGov.discoveryUrl)
   ]).then(function([keystore, issuer]){
-    loginGov.issuer = issuer; // allow subsequent access to issuer.end_session_endpoint (required during OIDC logout)
+    loginGov.issuer = issuer; // allow subsequent access to issuer.end_session_endpoint (required during RP-Initiated Logout)
 
     var client = new issuer.Client(clientOptions, keystore);
 
     var params = strategyParams(loaNumber);
 
     var strategy = new Strategy({client: client, params: params}, function(tokenset, userinfo, done) {
-      console.log("TOKEN SET", tokenset); // don't log in production
-      console.log("USER INFO", userinfo); // don't log in production
-      userinfo.token = tokenset.id_token; // required for OIDC logout
-      userinfo.state = params.state; // required for OIDC logout
+      console.log("TOKEN SET", tokenset);
+      console.log("USER INFO", userinfo);
+      userinfo.token = tokenset.id_token; // required for RP-Initiated Logout
+      userinfo.state = params.state; // required for RP-Initiated Logout
       return done(null, userinfo);
     });
 

--- a/routes/auth/login-gov.js
+++ b/routes/auth/login-gov.js
@@ -31,26 +31,22 @@ loginGovRoutes.configure = function(app, passport) {
     });
 
     // Logout from this application and from login.gov
-    app.get('/auth/login-gov/oidc-logout', function(req, res, next) {
+    // ... adapted from https://github.com/18F/fs-permit-platform/blob/6f3681a5861d96db76c279f726c23971f3e037c7/server/src/auth/passport-config.es6#L41-L56
+    app.get('/auth/login-gov/oidc-logout', function(req, res) {
         //req.logout();
 
-        const logoutUrl = `${loginGov.discoveryUrl}/openid_connect/logout` // TODO: get from issuer well-known config data
+        //console.log("LOGOUT USER", req.user)
+        //console.log("LOGOUT TOKEN", req.token)
+
+        //const logoutUrl = `${loginGov.discoveryUrl}/openid_connect/logout` // TODO: get from issuer well-known config data
+        const logoutUrl = loginGov.issuer.end_session_endpoint
+        const token = req.user.token
         const logoutRedirectUrl = process.env.LOGOUT_REDIRECT_URL || `http://localhost:${(process.env.PORT || '9393')}`
-        const token = "abc-123" // TODO: get from req.cookie OR req.session.passport.user
-        const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${loginGov.randomString(32)}`
+        const state = req.user.state
+        const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${state}`
+        //const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${loginGov.randomString(32)}`
 
-        //res.redirect(logoutUrl, {
-        //  search: null,
-        //  query: {
-        //    id_token_hint: "ABC-123",
-        //    state: loginGov.randomString(32),
-        //    post_logout_redirect_uri: logoutRedirectUrl
-        //  }
-        //});
-
-        res.redirect(requestUrl);
-
-        // return next();
+        return res.redirect(requestUrl);
     });
 
 };

--- a/routes/auth/login-gov.js
+++ b/routes/auth/login-gov.js
@@ -2,6 +2,8 @@ var loginGov = require('../../login-gov');
 
 var loginGovRoutes = {};
 
+var logoutPath = '/auth/login-gov/logout';
+
 loginGovRoutes.configure = function(app, passport) {
 
     //
@@ -25,7 +27,7 @@ loginGovRoutes.configure = function(app, passport) {
     //
 
     // Logout from this application, but not from login.gov
-    app.get('/auth/login-gov/logout', function(req, res) {
+    app.get(logoutPath, function(req, res) {
         req.logout();
         res.redirect('/');
     });
@@ -34,7 +36,8 @@ loginGovRoutes.configure = function(app, passport) {
     // ... adapted from https://github.com/18F/fs-permit-platform/blob/6f3681a5861d96db76c279f726c23971f3e037c7/server/src/auth/passport-config.es6#L41-L56
     app.get('/auth/login-gov/oidc-logout', function(req, res) {
         if (loginGov.issuer && req.user) {
-          const requestUrl = `${loginGov.issuer.end_session_endpoint}?id_token_hint=${req.user.token}&post_logout_redirect_uri=http://localhost:9393/&state=${req.user.state}`
+          var postLogoutRedirectUrl = `http://localhost:9393${logoutPath}`; // redirect to the logout path to sign the user out of this app after the response comes back, or else the user will still be signed in!
+          var requestUrl = `${loginGov.issuer.end_session_endpoint}?id_token_hint=${req.user.token}&post_logout_redirect_uri=${postLogoutRedirectUrl}&state=${req.user.state}`;
           return res.redirect(requestUrl);
         } else { // safeguard if user manually navigates to this route, avoids "Cannot read property 'token' of undefined"
           req.logout();

--- a/routes/auth/login-gov.js
+++ b/routes/auth/login-gov.js
@@ -33,20 +33,13 @@ loginGovRoutes.configure = function(app, passport) {
     // Logout from this application and from login.gov
     // ... adapted from https://github.com/18F/fs-permit-platform/blob/6f3681a5861d96db76c279f726c23971f3e037c7/server/src/auth/passport-config.es6#L41-L56
     app.get('/auth/login-gov/oidc-logout', function(req, res) {
-        //req.logout();
-
-        //console.log("LOGOUT USER", req.user)
-        //console.log("LOGOUT TOKEN", req.token)
-
-        //const logoutUrl = `${loginGov.discoveryUrl}/openid_connect/logout` // TODO: get from issuer well-known config data
-        const logoutUrl = loginGov.issuer.end_session_endpoint
-        const token = req.user.token
-        const logoutRedirectUrl = "http://localhost:9393/"
-        const state = req.user.state
-        const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${state}`
-        //const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${loginGov.randomString(32)}`
-
-        return res.redirect(requestUrl);
+        if (loginGov.issuer && req.user) {
+          const requestUrl = `${loginGov.issuer.end_session_endpoint}?id_token_hint=${req.user.token}&post_logout_redirect_uri=http://localhost:9393/&state=${req.user.state}`
+          return res.redirect(requestUrl);
+        } else { // safeguard if user manually navigates to this route, avoids "Cannot read property 'token' of undefined"
+          req.logout();
+          res.redirect('/');
+        };
     });
 
 };

--- a/routes/auth/login-gov.js
+++ b/routes/auth/login-gov.js
@@ -33,6 +33,7 @@ loginGovRoutes.configure = function(app, passport) {
     });
 
     // Logout from this application and from login.gov
+    // ... using RP-Initiated Logout
     // ... adapted from https://github.com/18F/fs-permit-platform/blob/6f3681a5861d96db76c279f726c23971f3e037c7/server/src/auth/passport-config.es6#L41-L56
     app.get('/auth/login-gov/oidc-logout', function(req, res) {
         if (loginGov.issuer && req.user) {

--- a/routes/auth/login-gov.js
+++ b/routes/auth/login-gov.js
@@ -1,3 +1,5 @@
+var loginGov = require('../../login-gov');
+
 var loginGovRoutes = {};
 
 loginGovRoutes.configure = function(app, passport) {
@@ -22,9 +24,33 @@ loginGovRoutes.configure = function(app, passport) {
     // LOGOUT
     //
 
+    // Logout from this application, but not from login.gov
     app.get('/auth/login-gov/logout', function(req, res) {
         req.logout();
         res.redirect('/');
+    });
+
+    // Logout from this application and from login.gov
+    app.get('/auth/login-gov/oidc-logout', function(req, res, next) {
+        //req.logout();
+
+        const logoutUrl = `${loginGov.discoveryUrl}/openid_connect/logout` // TODO: get from issuer well-known config data
+        const logoutRedirectUrl = process.env.LOGOUT_REDIRECT_URL || `http://localhost:${(process.env.PORT || '9393')}`
+        const token = "abc-123" // TODO: get from req.cookie OR req.session.passport.user
+        const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${loginGov.randomString(32)}`
+
+        //res.redirect(logoutUrl, {
+        //  search: null,
+        //  query: {
+        //    id_token_hint: "ABC-123",
+        //    state: loginGov.randomString(32),
+        //    post_logout_redirect_uri: logoutRedirectUrl
+        //  }
+        //});
+
+        res.redirect(requestUrl);
+
+        // return next();
     });
 
 };

--- a/routes/auth/login-gov.js
+++ b/routes/auth/login-gov.js
@@ -41,7 +41,7 @@ loginGovRoutes.configure = function(app, passport) {
         //const logoutUrl = `${loginGov.discoveryUrl}/openid_connect/logout` // TODO: get from issuer well-known config data
         const logoutUrl = loginGov.issuer.end_session_endpoint
         const token = req.user.token
-        const logoutRedirectUrl = process.env.LOGOUT_REDIRECT_URL || `http://localhost:${(process.env.PORT || '9393')}`
+        const logoutRedirectUrl = "http://localhost:9393/"
         const state = req.user.state
         const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${state}`
         //const requestUrl = `${logoutUrl}?id_token_hint=${token}&post_logout_redirect_uri=${logoutRedirectUrl}&state=${loginGov.randomString(32)}`

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -17,14 +17,14 @@
       </div-->
 
       <div class="mb1 right-align">
-        <a href="/auth/login-gov/login/loa-1" class="btn btn-outline bg-white navy">
+        <a href="/auth/login-gov/login/loa-1" class="btn btn-outline bg-white navy" title="Sign in via login.gov using Level of Access 1 (shares email and password only).">
           <img class="align-middle" width="125" src="/images/login-gov.svg" alt="Login gov">
           (LOA1)
         </a>
       </div>
 
       <div class="mb1 right-align">
-        <a href="/auth/login-gov/login/loa-3" class="btn btn-outline bg-white navy">
+        <a href="/auth/login-gov/login/loa-3" class="btn btn-outline bg-white navy" title="Sign in via login.gov using Level of Access 3 (shares all requested personal information).">
           <img class="align-middle" width="125" src="/images/login-gov.svg" alt="Login gov">
           (LOA3)
         </a>

--- a/views/success.ejs
+++ b/views/success.ejs
@@ -2,7 +2,7 @@
   <% if(typeof(user) != "undefined"){ %>
     <div class="right sm-show">
       <a href="/auth/login-gov/logout" title="Sign out of this application, but not login.gov.">Logout</a> |
-      <a href="/auth/login-gov/oidc-logout" title="Sign out of this application as well as login.gov.">OIDC Logout</a>
+      <a href="/auth/login-gov/oidc-logout" title="Sign out of this application as well as login.gov.">RP-Initiated Logout</a>
     </div>
 
     <span class="bold">Success!</span>

--- a/views/success.ejs
+++ b/views/success.ejs
@@ -1,7 +1,8 @@
 <div class="p2 bg-green white clearfix">
   <% if(typeof(user) != "undefined"){ %>
     <div class="right sm-show">
-      <a href="/auth/login-gov/logout">Logout</a>
+      <a href="/auth/login-gov/logout">Logout</a> |
+      <a href="/auth/login-gov/oidc-logout">OIDC Logout</a>
     </div>
 
     <span class="bold">Success!</span>

--- a/views/success.ejs
+++ b/views/success.ejs
@@ -1,8 +1,8 @@
 <div class="p2 bg-green white clearfix">
   <% if(typeof(user) != "undefined"){ %>
     <div class="right sm-show">
-      <a href="/auth/login-gov/logout">Logout</a> |
-      <a href="/auth/login-gov/oidc-logout">OIDC Logout</a>
+      <a href="/auth/login-gov/logout" title="Sign out of this application, but not login.gov.">Logout</a> |
+      <a href="/auth/login-gov/oidc-logout" title="Sign out of this application as well as login.gov.">OIDC Logout</a>
     </div>
 
     <span class="bold">Success!</span>


### PR DESCRIPTION
Resolves #9.

Additions:

  + Implements an optional RP-Initiated Logout whereby the user is also signed out of login.gov.
  + Provides more context (via link titles) to the user about various login and logout options. 

Revisions:

  + Removes environment variables which need specific values to match the corresponding login.gov service provider configuration, so configuring them wouldn't provide value.
  + Exports additional variables and functions as part of the `login-gov` module.

Credits and Reference:

  + [OIDC Specs: RP-Initiated Logout](https://openid.net/specs/openid-connect-session-1_0.html#RPLogout)
  + [Login.gov Docs: OIDC Logout](https://developers.login.gov/openid-connect/#logout)
  + [As implemented in 18F's fs-permit-platform](https://github.com/18F/fs-permit-platform/blob/8847e5ef25f67bac1123cd1e7d4feaa9287f3803/server/src/auth/login-gov.es6#L96-L104)
